### PR TITLE
Fix Bugs

### DIFF
--- a/infrastructure/terraform/modules/logicapp/locals.tf
+++ b/infrastructure/terraform/modules/logicapp/locals.tf
@@ -1,7 +1,7 @@
 locals {
   logic_app_application_settings_default = {
     FUNCTIONS_WORKER_RUNTIME     = "node"
-    WEBSITE_NODE_DEFAULT_VERSION = "~18"
+    WEBSITE_NODE_DEFAULT_VERSION = "~20"
     # WEBSITE_RUN_FROM_PACKAGE     = "1"
   }
   logic_app_application_settings_connection_runtime_urls = {

--- a/infrastructure/terraform/modules/logicapp/locals.tf
+++ b/infrastructure/terraform/modules/logicapp/locals.tf
@@ -5,7 +5,7 @@ locals {
     # WEBSITE_RUN_FROM_PACKAGE     = "1"
   }
   logic_app_application_settings_connection_runtime_urls = {
-    for key, value in azapi_resource.api_connection_arm :
+    for key, value in azapi_resource.api_connections :
     "${title(key)}ConnectionRuntimeUrl" => jsondecode(value.output).properties.connectionRuntimeUrl
   }
   logic_app_application_settings = merge(local.logic_app_application_settings_default, local.logic_app_application_settings_connection_runtime_urls, var.logic_app_application_settings)

--- a/infrastructure/terraform/modules/logicapp/logicapp.tf
+++ b/infrastructure/terraform/modules/logicapp/logicapp.tf
@@ -11,7 +11,7 @@ resource "azurerm_logic_app_standard" "logic_app_standard" {
   app_settings               = local.logic_app_application_settings
   bundle_version             = "[1.*, 2.0.0)"
   client_affinity_enabled    = false
-  client_certificate_mode    = "Required"
+  client_certificate_mode    = "Optional"
   enabled                    = true
   https_only                 = true
   storage_account_access_key = data.azurerm_storage_account.storage_account.primary_access_key

--- a/infrastructure/terraform/modules/logicapp/logicapp_apiconnections.tf
+++ b/infrastructure/terraform/modules/logicapp/logicapp_apiconnections.tf
@@ -40,12 +40,12 @@ resource "azapi_resource" "api_connections" {
   response_export_values    = ["properties.connectionRuntimeUrl"]
 }
 
-resource "azapi_resource" "api_connection__access_policies" {
-  for_each = azapi_resource.api_connections
+resource "azapi_resource" "api_connection_access_policies" {
+  for_each = var.logic_app_api_connections
 
   type      = "Microsoft.Web/connections/accessPolicies@2016-06-01"
-  parent_id = each.value.id
-  name      = "${each.value.name}-${azurerm_logic_app_standard.logic_app_standard.identity[0].principal_id}"
+  parent_id = azapi_resource.api_connections[each.key].id
+  name      = "${each.key}-${azurerm_logic_app_standard.logic_app_standard.identity[0].principal_id}"
   location  = var.location
 
   body = jsonencode({

--- a/infrastructure/terraform/modules/storageaccount/output.tf
+++ b/infrastructure/terraform/modules/storageaccount/output.tf
@@ -10,6 +10,12 @@ output "storage_account_name" {
   sensitive   = false
 }
 
+output "storage_account_resource_group_name" {
+  value       = azurerm_storage_account.storage.resource_group_name
+  description = "Specifies the resource group name of the storage account"
+  sensitive   = false
+}
+
 output "storage_account_primary_blob_endpoint" {
   value       = azurerm_storage_account.storage.primary_blob_endpoint
   description = "Specifies the primary blob endpoint of the storage account"

--- a/infrastructure/terraform/orchestration.tf
+++ b/infrastructure/terraform/orchestration.tf
@@ -108,6 +108,14 @@ resource "azurerm_role_assignment" "logic_app_role_assignment_storage_blob_data_
   principal_type       = "ServicePrincipal"
 }
 
+resource "azurerm_role_assignment" "logic_app_role_assignment_storage_blob_delegator" {
+  description          = "Role Assignment for Data Factory to generate SAS tokens."
+  scope                = module.storage_account.storage_account_id
+  role_definition_name = "Storage Blob Delegator"
+  principal_id         = module.logic_app_orchestration.logic_app_principal_id
+  principal_type       = "ServicePrincipal"
+}
+
 resource "azurerm_role_assignment" "logic_app_role_assignment_open_ai" {
   description          = "Role Assignment for Data Factory to interact with Open AI models"
   scope                = module.open_ai.cognitive_account_id

--- a/infrastructure/terraform/orchestration.tf
+++ b/infrastructure/terraform/orchestration.tf
@@ -52,6 +52,7 @@ module "logic_app_orchestration" {
     APPLICATIONINSIGHTS_CONNECTION_STRING = module.application_insights_orchestration.application_insights_connection_string
     WEBSITE_RUN_FROM_PACKAGE              = "1"
     # App specific settings
+    LOGIC_APP_ID                        = "/subscriptions/${data.azurerm_subscription.current.subscription_id}/resourceGroups/${azurerm_resource_group.orchestration.name}/providers/Microsoft.Web/sites/${local.logic_app_name}"
     AZURE_BLOB_STORAGE_ENDPOINT         = module.storage_account.storage_account_primary_blob_endpoint
     STORAGE_ACCOUNT_SUBSCRIPTION_ID     = data.azurerm_subscription.current.subscription_id
     STORAGE_ACCOUNT_RESOURCE_GROUP_NAME = module.storage_account.storage_account_resource_group_name
@@ -108,6 +109,14 @@ resource "azurerm_role_assignment" "logic_app_role_assignment_storage_blob_data_
   description          = "Role Assignment for Data Factory to read and write data"
   scope                = module.storage_account.storage_account_id
   role_definition_name = "Storage Blob Data Owner"
+  principal_id         = module.logic_app_orchestration.logic_app_principal_id
+  principal_type       = "ServicePrincipal"
+}
+
+resource "azurerm_role_assignment" "logic_app_role_assignment_logic_apps_standard_operator" {
+  description          = "Role Assignment for Logic App to dynamically fetch callback URIs"
+  scope                = module.logic_app_orchestration.logic_app_id
+  role_definition_name = "Logic Apps Standard Operator (Preview)"
   principal_id         = module.logic_app_orchestration.logic_app_principal_id
   principal_type       = "ServicePrincipal"
 }

--- a/infrastructure/terraform/orchestration.tf
+++ b/infrastructure/terraform/orchestration.tf
@@ -50,6 +50,7 @@ module "logic_app_orchestration" {
     # Logic App config settings
     APPINSIGHTS_INSTRUMENTATIONKEY        = module.application_insights_orchestration.application_insights_instrumentation_key
     APPLICATIONINSIGHTS_CONNECTION_STRING = module.application_insights_orchestration.application_insights_connection_string
+    WEBSITE_RUN_FROM_PACKAGE              = "1"
     # App specific settings
     AZURE_BLOB_STORAGE_ENDPOINT         = module.storage_account.storage_account_primary_blob_endpoint
     STORAGE_ACCOUNT_SUBSCRIPTION_ID     = data.azurerm_subscription.current.subscription_id

--- a/infrastructure/terraform/orchestration.tf
+++ b/infrastructure/terraform/orchestration.tf
@@ -51,18 +51,21 @@ module "logic_app_orchestration" {
     APPINSIGHTS_INSTRUMENTATIONKEY        = module.application_insights_orchestration.application_insights_instrumentation_key
     APPLICATIONINSIGHTS_CONNECTION_STRING = module.application_insights_orchestration.application_insights_connection_string
     # App specific settings
-    AZURE_BLOB_STORAGE_ENDPOINT    = module.storage_account.storage_account_primary_blob_endpoint
-    STORAGE_CONTAINER_NAME_RAW     = local.container_name_raw
-    STORAGE_CONTAINER_NAME_CURATED = local.container_name_curated
-    AZURE_OPENAI_ENDPOINT          = module.open_ai.cognitive_account_endpoint
-    AZURE_OPENAI_DEPLOYMENT_NAME   = "gpt-4"
-    VIDEO_INDEXER_ID               = module.videoindexer.videoindexer_id
-    VIDEO_INDEXER_ACCOUNT_ID       = module.videoindexer.videoindexer_account_id
-    WORKFLOWS_SUBSCRIPTION_ID      = data.azurerm_subscription.current.subscription_id
-    WORKFLOWS_RESOURCE_GROUP_NAME  = azurerm_resource_group.orchestration.name
-    WORKFLOWS_LOCATION_NAME        = local.location
-    FUNCTION_SHORTCLIP_HOSTNAME    = module.function_shortclip.linux_function_app_default_hostname
-    FUNCTION_SHORTCLIP_KEY         = module.function_shortclip.linux_function_app_primary_key
+    AZURE_BLOB_STORAGE_ENDPOINT         = module.storage_account.storage_account_primary_blob_endpoint
+    STORAGE_ACCOUNT_SUBSCRIPTION_ID     = data.azurerm_subscription.current.subscription_id
+    STORAGE_ACCOUNT_RESOURCE_GROUP_NAME = module.storage_account.storage_account_resource_group_name
+    STORAGE_ACCOUNT_NAME                = module.storage_account.storage_account_name
+    STORAGE_CONTAINER_NAME_RAW          = local.container_name_raw
+    STORAGE_CONTAINER_NAME_CURATED      = local.container_name_curated
+    AZURE_OPENAI_ENDPOINT               = module.open_ai.cognitive_account_endpoint
+    AZURE_OPENAI_DEPLOYMENT_NAME        = "gpt-4"
+    VIDEO_INDEXER_ID                    = module.videoindexer.videoindexer_id
+    VIDEO_INDEXER_ACCOUNT_ID            = module.videoindexer.videoindexer_account_id
+    WORKFLOWS_SUBSCRIPTION_ID           = data.azurerm_subscription.current.subscription_id
+    WORKFLOWS_RESOURCE_GROUP_NAME       = azurerm_resource_group.orchestration.name
+    WORKFLOWS_LOCATION_NAME             = local.location
+    FUNCTION_SHORTCLIP_HOSTNAME         = module.function_shortclip.linux_function_app_default_hostname
+    FUNCTION_SHORTCLIP_KEY              = module.function_shortclip.linux_function_app_primary_key
   }
   logic_app_always_on                                = true
   logic_app_code_path                                = "${path.module}/../../utilities/logicApp"
@@ -108,10 +111,10 @@ resource "azurerm_role_assignment" "logic_app_role_assignment_storage_blob_data_
   principal_type       = "ServicePrincipal"
 }
 
-resource "azurerm_role_assignment" "logic_app_role_assignment_storage_blob_delegator" {
+resource "azurerm_role_assignment" "logic_app_role_assignment_storage_account_contributor" {
   description          = "Role Assignment for Data Factory to generate SAS tokens."
   scope                = module.storage_account.storage_account_id
-  role_definition_name = "Storage Blob Delegator"
+  role_definition_name = "Storage Account Contributor"
   principal_id         = module.logic_app_orchestration.logic_app_principal_id
   principal_type       = "ServicePrincipal"
 }

--- a/utilities/logicApp/VideoIndexer-Workflow/workflow.json
+++ b/utilities/logicApp/VideoIndexer-Workflow/workflow.json
@@ -58,7 +58,7 @@
                     "path": "/@{encodeURIComponent(parameters('WORKFLOWS_LOCATION_NAME'))}/Accounts/@{encodeURIComponent(parameters('VIDEO_INDEXER_ACCOUNT_ID'))}/Videos",
                     "queries": {
                         "accessToken": "@body('Arm-VideoIndexerGenerateAccessToken-Response')?['accessToken']",
-                        "name": "@{concat(triggerBody()?['properties']?['blobTierLastModifiedTime'], triggerBody()?['name'])}",
+                        "name": "@{concat(utcNow('yyyy-MM-dd-HH-mm-ss'),'-', triggerBody()?['name'])}",
                         "videoUrl": "@{concat('https://',parameters('STORAGE_ACCOUNT_NAME'),'.blob.core.windows.net',triggerBody()?['properties']?['blobFullPathWithContainer'],'?',body('Arm-StorageListServiceSas-Response')?['serviceSasToken'])}"
                     }
                 },
@@ -68,50 +68,17 @@
                     ]
                 }
             },
-            "OpenAi-CreateAssisstant-Request": {
-                "type": "Http",
-                "inputs": {
-                    "uri": "@concat(parameters('AZURE_OPENAI_ENDPOINT'),'/openai/assistants?api-version=2024-03-01-preview')",
-                    "method": "POST",
-                    "body": {
-                        "instructions": "@{parameters('META_PROMPT')}",
-                        "name": "esp1",
-                        "model": "gpt-4",
-                        "file_ids": [
-                            "@{body('Videoindexer-UploadAndIndex')?['id']}"
-                        ],
-                        "tools": [
-                            {
-                                "type": "code_interpreter"
-                            },
-                            {
-                                "type": "retrieval"
-                            }
-                        ]
-                    }
-                },
-                "runAfter": {
-                    "Videoindexer-UploadAndIndex": [
-                        "SUCCEEDED"
-                    ]
-                },
-                "runtimeConfiguration": {
-                    "contentTransfer": {
-                        "transferMode": "Chunked"
-                    }
-                }
-            },
             "Arm-StorageListServiceSas-Request": {
                 "type": "Http",
                 "inputs": {
                     "uri": "@concat('https://management.azure.com/subscriptions/',parameters('STORAGE_ACCOUNT_SUBSCRIPTION_ID'),'/resourceGroups/',parameters('STORAGE_ACCOUNT_RESOURCE_GROUP_NAME'),'/providers/Microsoft.Storage/storageAccounts/',parameters('STORAGE_ACCOUNT_NAME'), '/ListServiceSas?api-version=2023-01-01')",
                     "method": "POST",
                     "body": {
-                        "canonicalizedResource": "/blob@{parameters('STORAGE_ACCOUNT_NAME')}@{triggerBody()?['properties']?['blobFullPathWithContainer']}",
+                        "canonicalizedResource": "/blob/@{parameters('STORAGE_ACCOUNT_NAME')}@{triggerBody()?['properties']?['blobFullPathWithContainer']}",
                         "signedResource": "b",
                         "signedPermission": "r",
                         "signedProtocol": "https",
-                        "signedExpiry": "@{getFutureTime(1, 'Hour', 'o')}"
+                        "signedExpiry": "@{getFutureTime(3, 'Hour', 'o')}"
                     },
                     "authentication": {
                         "type": "ManagedServiceIdentity",
@@ -143,27 +110,6 @@
                         "SUCCEEDED"
                     ]
                 }
-            },
-            "BlobSASURI-BlobFile": {
-                "type": "ServiceProvider",
-                "inputs": {
-                    "parameters": {
-                        "containerName": "@triggerBody()?['containerInfo']?['name']",
-                        "blobName": "@triggerBody()?['name']",
-                        "permissions": "Read",
-                        "sharedAccessProtocol": "Https"
-                    },
-                    "serviceProviderConfiguration": {
-                        "connectionName": "AzureBlob",
-                        "operationId": "getBlobSASUri",
-                        "serviceProviderId": "/serviceProviders/AzureBlob"
-                    }
-                },
-                "runAfter": {
-                    "OpenAi-CreateAssisstant-Request": [
-                        "SUCCEEDED"
-                    ]
-                }
             }
         },
         "contentVersion": "1.0.0.0",
@@ -173,7 +119,7 @@
                 "type": "ServiceProvider",
                 "inputs": {
                     "parameters": {
-                        "path": "@parameters('STORAGE_CONTAINER_NAME_RAW')"
+                        "path": "@concat(parameters('STORAGE_CONTAINER_NAME_RAW'),'/videos/{blobname}.{blobextension}')"
                     },
                     "serviceProviderConfiguration": {
                         "connectionName": "AzureBlob",

--- a/utilities/logicApp/VideoIndexer-Workflow/workflow.json
+++ b/utilities/logicApp/VideoIndexer-Workflow/workflow.json
@@ -17,7 +17,11 @@
                         "serviceProviderId": "/serviceProviders/AzureBlob"
                     }
                 },
-                "runAfter": {}
+                "runAfter": {
+                    "Arm-StorageListServiceSas-Request": [
+                        "SUCCEEDED"
+                    ]
+                }
             },
             "Arm-VideoIndexerGenerateAccessToken-Request": {
                 "type": "Http",
@@ -112,6 +116,25 @@
                         "SUCCEEDED"
                     ]
                 },
+                "runtimeConfiguration": {
+                    "contentTransfer": {
+                        "transferMode": "Chunked"
+                    }
+                }
+            },
+            "Arm-StorageListServiceSas-Request": {
+                "type": "Http",
+                "inputs": {
+                    "uri": "@concat('https://management.azure.com/subscriptions/',parameters('STORAGE_ACCOUNT_SUBSCRIPTION_ID'),'/resourceGroups/',parameters('STORAGE_ACCOUNT_RESOURCE_GROUP_NAME'),'/providers/Microsoft.Storage/storageAccounts/',parameters('STORAGE_ACCOUNT_NAME'), '/ListServiceSas?api-version=2023-01-01')",
+                    "method": "POST",
+                    "body": {
+                        "canonicalizedResource": "/blob@{triggerBody()?['properties']?['blobFullPathWithContainer']}",
+                        "signedResource": "c",
+                        "signedPermission": "r",
+                        "signedProtocol": "https"
+                    }
+                },
+                "runAfter": {},
                 "runtimeConfiguration": {
                     "contentTransfer": {
                         "transferMode": "Chunked"

--- a/utilities/logicApp/VideoIndexer-Workflow/workflow.json
+++ b/utilities/logicApp/VideoIndexer-Workflow/workflow.json
@@ -2,27 +2,6 @@
     "definition": {
         "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
         "actions": {
-            "BlobSASURI-BlobFile": {
-                "type": "ServiceProvider",
-                "inputs": {
-                    "parameters": {
-                        "containerName": "@triggerBody()?['containerInfo']?['name']",
-                        "blobName": "@triggerBody()?['name']",
-                        "permissions": "Read",
-                        "sharedAccessProtocol": "Https"
-                    },
-                    "serviceProviderConfiguration": {
-                        "connectionName": "AzureBlob",
-                        "operationId": "getBlobSASUri",
-                        "serviceProviderId": "/serviceProviders/AzureBlob"
-                    }
-                },
-                "runAfter": {
-                    "Arm-StorageListServiceSas-Request": [
-                        "SUCCEEDED"
-                    ]
-                }
-            },
             "Arm-VideoIndexerGenerateAccessToken-Request": {
                 "type": "Http",
                 "inputs": {
@@ -38,7 +17,7 @@
                     }
                 },
                 "runAfter": {
-                    "BlobSASURI-BlobFile": [
+                    "Arm-StorageListServiceSas-Response": [
                         "SUCCEEDED"
                     ]
                 },
@@ -80,7 +59,7 @@
                     "queries": {
                         "accessToken": "@body('Arm-VideoIndexerGenerateAccessToken-Response')?['accessToken']",
                         "name": "@{concat(triggerBody()?['properties']?['blobTierLastModifiedTime'], triggerBody()?['name'])}",
-                        "videoUrl": "@{body('BlobSASURI-BlobFile')?['blobUri']}"
+                        "videoUrl": "@{concat('https://',parameters('STORAGE_ACCOUNT_NAME'),'.blob.core.windows.net',triggerBody()?['properties']?['blobFullPathWithContainer'],'?',body('Arm-StorageListServiceSas-Response')?['serviceSasToken'])}"
                     }
                 },
                 "runAfter": {
@@ -128,10 +107,15 @@
                     "uri": "@concat('https://management.azure.com/subscriptions/',parameters('STORAGE_ACCOUNT_SUBSCRIPTION_ID'),'/resourceGroups/',parameters('STORAGE_ACCOUNT_RESOURCE_GROUP_NAME'),'/providers/Microsoft.Storage/storageAccounts/',parameters('STORAGE_ACCOUNT_NAME'), '/ListServiceSas?api-version=2023-01-01')",
                     "method": "POST",
                     "body": {
-                        "canonicalizedResource": "/blob@{triggerBody()?['properties']?['blobFullPathWithContainer']}",
-                        "signedResource": "c",
+                        "canonicalizedResource": "/blob@{parameters('STORAGE_ACCOUNT_NAME')}@{triggerBody()?['properties']?['blobFullPathWithContainer']}",
+                        "signedResource": "b",
                         "signedPermission": "r",
-                        "signedProtocol": "https"
+                        "signedProtocol": "https",
+                        "signedExpiry": "@{getFutureTime(1, 'Hour', 'o')}"
+                    },
+                    "authentication": {
+                        "type": "ManagedServiceIdentity",
+                        "audience": "https://management.core.windows.net"
                     }
                 },
                 "runAfter": {},
@@ -139,6 +123,46 @@
                     "contentTransfer": {
                         "transferMode": "Chunked"
                     }
+                }
+            },
+            "Arm-StorageListServiceSas-Response": {
+                "type": "ParseJson",
+                "inputs": {
+                    "content": "@body('Arm-StorageListServiceSas-Request')",
+                    "schema": {
+                        "type": "object",
+                        "properties": {
+                            "serviceSasToken": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "runAfter": {
+                    "Arm-StorageListServiceSas-Request": [
+                        "SUCCEEDED"
+                    ]
+                }
+            },
+            "BlobSASURI-BlobFile": {
+                "type": "ServiceProvider",
+                "inputs": {
+                    "parameters": {
+                        "containerName": "@triggerBody()?['containerInfo']?['name']",
+                        "blobName": "@triggerBody()?['name']",
+                        "permissions": "Read",
+                        "sharedAccessProtocol": "Https"
+                    },
+                    "serviceProviderConfiguration": {
+                        "connectionName": "AzureBlob",
+                        "operationId": "getBlobSASUri",
+                        "serviceProviderId": "/serviceProviders/AzureBlob"
+                    }
+                },
+                "runAfter": {
+                    "OpenAi-CreateAssisstant-Request": [
+                        "SUCCEEDED"
+                    ]
                 }
             }
         },

--- a/utilities/logicApp/VideoIndexer-Workflow/workflow.json
+++ b/utilities/logicApp/VideoIndexer-Workflow/workflow.json
@@ -59,11 +59,12 @@
                     "queries": {
                         "accessToken": "@body('Arm-VideoIndexerGenerateAccessToken-Response')?['accessToken']",
                         "name": "@{concat(utcNow('yyyy-MM-dd-HH-mm-ss'),'-', triggerBody()?['name'])}",
-                        "videoUrl": "@{concat('https://',parameters('STORAGE_ACCOUNT_NAME'),'.blob.core.windows.net',triggerBody()?['properties']?['blobFullPathWithContainer'],'?',body('Arm-StorageListServiceSas-Response')?['serviceSasToken'])}"
+                        "videoUrl": "@{concat('https://',parameters('STORAGE_ACCOUNT_NAME'),'.blob.core.windows.net',triggerBody()?['properties']?['blobFullPathWithContainer'],'?',body('Arm-StorageListServiceSas-Response')?['serviceSasToken'])}",
+                        "callbackUrl": "@body('Arm-LogicAppListCallbackUri-Response')?['value']"
                     }
                 },
                 "runAfter": {
-                    "Arm-VideoIndexerGenerateAccessToken-Response": [
+                    "Arm-LogicAppListCallbackUri-Response": [
                         "SUCCEEDED"
                     ]
                 }
@@ -107,6 +108,69 @@
                 },
                 "runAfter": {
                     "Arm-StorageListServiceSas-Request": [
+                        "SUCCEEDED"
+                    ]
+                }
+            },
+            "Arm-LogicAppListCallbackUri-Request": {
+                "type": "Http",
+                "inputs": {
+                    "uri": "@concat('https://management.azure.com',parameters('LOGIC_APP_ID'),'/hostruntime/runtime/webhooks/workflow/api/management/workflows/Callback-Workflow/triggers/HTTPTrigger/listCallbackUrl?api-version=2018-11-01')",
+                    "method": "POST",
+                    "authentication": {
+                        "type": "ManagedServiceIdentity",
+                        "audience": "https://management.core.windows.net"
+                    }
+                },
+                "runAfter": {
+                    "Arm-VideoIndexerGenerateAccessToken-Response": [
+                        "SUCCEEDED"
+                    ]
+                },
+                "runtimeConfiguration": {
+                    "contentTransfer": {
+                        "transferMode": "Chunked"
+                    }
+                }
+            },
+            "Arm-LogicAppListCallbackUri-Response": {
+                "type": "ParseJson",
+                "inputs": {
+                    "content": "@body('Arm-LogicAppListCallbackUri-Request')",
+                    "schema": {
+                        "type": "object",
+                        "properties": {
+                            "value": {
+                                "type": "string"
+                            },
+                            "method": {
+                                "type": "string"
+                            },
+                            "basePath": {
+                                "type": "string"
+                            },
+                            "queries": {
+                                "type": "object",
+                                "properties": {
+                                    "api-version": {
+                                        "type": "string"
+                                    },
+                                    "sp": {
+                                        "type": "string"
+                                    },
+                                    "sv": {
+                                        "type": "string"
+                                    },
+                                    "sig": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "runAfter": {
+                    "Arm-LogicAppListCallbackUri-Request": [
                         "SUCCEEDED"
                     ]
                 }

--- a/utilities/logicApp/parameters.json
+++ b/utilities/logicApp/parameters.json
@@ -1,4 +1,16 @@
 {
+  "STORAGE_ACCOUNT_SUBSCRIPTION_ID": {
+    "type": "String",
+    "value": "@appsetting('STORAGE_ACCOUNT_SUBSCRIPTION_ID')"
+  },
+  "STORAGE_ACCOUNT_RESOURCE_GROUP_NAME": {
+    "type": "String",
+    "value": "@appsetting('STORAGE_ACCOUNT_RESOURCE_GROUP_NAME')"
+  },
+  "STORAGE_ACCOUNT_NAME": {
+    "type": "String",
+    "value": "@appsetting('STORAGE_ACCOUNT_NAME')"
+  },
   "STORAGE_CONTAINER_NAME_RAW": {
     "type": "String",
     "value": "@appsetting('STORAGE_CONTAINER_NAME_RAW')"
@@ -74,17 +86,5 @@
   "FUNCTION_SHORTCLIP_KEY": {
     "type": "String",
     "value": "@appsetting('FUNCTION_SHORTCLIP_KEY')"
-  },
-  "STORAGE_ACCOUNT_SUBSCRIPTION_ID": {
-    "type": "String",
-    "value": "@appsetting('STORAGE_ACCOUNT_SUBSCRIPTION_ID')"
-  },
-  "STORAGE_ACCOUNT_RESOURCE_GROUP_NAME": {
-    "type": "String",
-    "value": "@appsetting('STORAGE_ACCOUNT_RESOURCE_GROUP_NAME')"
-  },
-  "STORAGE_ACCOUNT_NAME": {
-    "type": "String",
-    "value": "@appsetting('STORAGE_ACCOUNT_NAME')"
   }
 }

--- a/utilities/logicApp/parameters.json
+++ b/utilities/logicApp/parameters.json
@@ -58,9 +58,7 @@
   "ConversionserviceAuthentication": {
     "type": "Object",
     "value": {
-      "type": "Raw",
-      "scheme": "Key",
-      "parameter": "@appsetting('ConversionserviceConnectionKey')"
+      "type": "ManagedServiceIdentity"
     }
   },
   "Videoindexer-V2ConnectionRuntimeUrl": {
@@ -70,9 +68,7 @@
   "Videoindexer-V2Authentication": {
     "type": "Object",
     "value": {
-      "type": "Raw",
-      "scheme": "Key",
-      "parameter": "@appsetting('Videoindexer-V2ConnectionKey')"
+      "type": "ManagedServiceIdentity"
     }
   },
   "AZURE_BLOB_STORAGE_ENDPOINT": {
@@ -86,5 +82,9 @@
   "FUNCTION_SHORTCLIP_KEY": {
     "type": "String",
     "value": "@appsetting('FUNCTION_SHORTCLIP_KEY')"
+  },
+  "CALLBACK_WORKFLOW_RELATIVE_PATH": {
+    "type": "String",
+    "value": "/videoindexer/callback"
   }
 }

--- a/utilities/logicApp/parameters.json
+++ b/utilities/logicApp/parameters.json
@@ -74,5 +74,17 @@
   "FUNCTION_SHORTCLIP_KEY": {
     "type": "String",
     "value": "@appsetting('FUNCTION_SHORTCLIP_KEY')"
+  },
+  "STORAGE_ACCOUNT_SUBSCRIPTION_ID": {
+    "type": "String",
+    "value": "@appsetting('STORAGE_ACCOUNT_SUBSCRIPTION_ID')"
+  },
+  "STORAGE_ACCOUNT_RESOURCE_GROUP_NAME": {
+    "type": "String",
+    "value": "@appsetting('STORAGE_ACCOUNT_RESOURCE_GROUP_NAME')"
+  },
+  "STORAGE_ACCOUNT_NAME": {
+    "type": "String",
+    "value": "@appsetting('STORAGE_ACCOUNT_NAME')"
   }
 }

--- a/utilities/logicApp/parameters.json
+++ b/utilities/logicApp/parameters.json
@@ -83,8 +83,8 @@
     "type": "String",
     "value": "@appsetting('FUNCTION_SHORTCLIP_KEY')"
   },
-  "CALLBACK_WORKFLOW_RELATIVE_PATH": {
+  "LOGIC_APP_ID": {
     "type": "String",
-    "value": "/videoindexer/callback"
+    "value": "@appsetting('LOGIC_APP_ID')"
   }
 }


### PR DESCRIPTION
**Proposed changes**:
- Add Web Connections Access Policies via azapi provider instead of using ARM templates.
- Add `Storage Account Contributor` Permission for Logic App to generate SAS tokens using ARM REST API (Reference: https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/tutorial-windows-vm-access-storage-sas).
- Switch to ARM API for SAS token and scope SAS token to blob instead of the account. Parse the response using a JSON activity.
- Limit SAS token validity to 3 hours. We can reduce this further over time in case the video indexer consistently require less time.
- Update authentication to rely on managed identities for managed APIs instead of keys.
- Update folder to which the trigger for the Video Indexer workflow listens to `concat(parameters('STORAGE_CONTAINER_NAME_RAW'),'/videos/{blobname}.{blobextension}')`. Now, it only checks for files uploaded into the `videos` directory. Reference: https://learn.microsoft.com/en-us/azure/connectors/connectors-create-api-azureblobstorage?tabs=standard#built-in-connector-trigger
- Parametrize Video Name in Video Indexer to ensure different names, in case the video gets processed  twice for some reason (e.g. service errors, reprocessing required, etc.). It will now use the current timestamp plus the original file name (e.g. `<timestamp>-<file-name>-<file extension>`).
- Add logic app app settings `WEBSITE_RUN_FROM_PACKAGE              = "1"` to ensure code deployed via CICD is being executed.
- Add role assignment `Logic Apps Standard Operator (Preview)` for Logic App to logic app resource scope to allow dynamically fetching the callback URI of other workflows.
- Add activities to workflow to dynamically fetch callback URI for Video Indexer activity and pass property to video indexer.
- Switch to node version 20 for Logic App Standard
- Update client cert mode from `Required` to `Optional`