### PR TITLE
Including Cognitive Services account principal Id

### DIFF
--- a/infrastructure/terraform/modules/aoai/outputs.tf
+++ b/infrastructure/terraform/modules/aoai/outputs.tf
@@ -17,3 +17,9 @@ output "azurerm_cognitive_account_endpoint" {
   description = "The base URL of the cognitive service account."
   value       = azurerm_cognitive_account.cognitive_service.endpoint
 }
+
+output "azurerm_cognitive_account_principal_id" {
+  description = "The principal id of the cognitive services account."
+  sensitive   = false
+  value       = azurerm_cognitive_account.cognitive_service.identity[0].principal_id
+}


### PR DESCRIPTION
Including Cognitive Services Account principal Id in the AOAI module, as some Azure Cognitive services, like Document Intelligence, require role assignments on their principal Id when interacting with other services (for example, Storage account).