### PR TITLE
outputs file for aisearch module

### DIFF
--- a/infrastructure/terraform/modules/aisearch/outputs.tf
+++ b/infrastructure/terraform/modules/aisearch/outputs.tf
@@ -1,0 +1,10 @@
+output "search_service_account_id" {
+  description = "The ID of the cognitive service account."
+  value       = azurerm_search_service.search_service.id
+}
+
+output "search_service_principal_id" {
+  description = "Specifies the principal id of the AI Search account."
+  sensitive   = false
+  value       = azurerm_search_service.search_service.identity[0].principal_id
+}


### PR DESCRIPTION
Including outputs.tf file for aisearch module, as outputs can be used when integrating Azure AI Search with other Azure services (such as Azure OpenAI and Storage Account), for example, for role assignments.