### PR TITLE
removing authentication_failure_mode property

### DIFF
--- a/infrastructure/terraform/modules/aisearch/aisearch.tf
+++ b/infrastructure/terraform/modules/aisearch/aisearch.tf
@@ -8,7 +8,6 @@ resource "azurerm_search_service" "search_service" {
   }
 
   allowed_ips                 = []
-  authentication_failure_mode = "http401WithBearerChallenge"
   hosting_mode                = "default"
 
   sku                                      = var.search_service_sku


### PR DESCRIPTION
This PR removes the authentication_failure_mode property from the azurerm_search_service Terraform module.

As per the documentation, this property can only be configured when local_authentication_enabled is set to true, which is not our case, as we deploy Azure AI Search with local_authentication_enabled set to false.

Here's the snippet from the Terraform documentation (https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/search_service):

![Screenshot 2024-06-06 at 13 38 39](https://github.com/Azure/ai-hub/assets/16934655/19e282bb-2975-431b-8b44-14737bcc78d0)



